### PR TITLE
Using Angular's $log service for IE8 compatibility

### DIFF
--- a/src/angular-post-message.js
+++ b/src/angular-post-message.js
@@ -5,8 +5,8 @@
   app = angular.module("ngPostMessage", ['ng']);
 
   app.run([
-    '$window', '$postMessage', '$rootScope',
-    function($window, $postMessage, $rootScope) {
+    '$window', '$postMessage', '$rootScope', '$log',
+    function($window, $postMessage, $rootScope, $log) {
 
       $rootScope.$on('$messageOutgoing', function(event, message, domain) {
         var sender;
@@ -27,7 +27,7 @@
             response = angular.fromJson(event.data);
           } catch (_error) {
             error = _error;
-            console.error('ahem', error);
+            $log.error('ahem', error);
             response = event.data;
           }
           $rootScope.$root.$broadcast('$messageIncoming', response);


### PR DESCRIPTION
When there is a parse error in IE8 the console.log expression in the catch block is throwing a "console is not defined" error. Using Angular's $log service prevents this.
