### PR TITLE
Handle non JSON formatted messages

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.4.0
+
+* Handle non JSON formatted messages. Message will be added to the `text` property of the response object.
+
 ## v1.3.1
 
 * Expose post message event.origin to listeners [5730fdc](https://github.com/kylewelsby/angular-post-message/commit/5730fdc93d96a3bc6cbb21eea7e37d14aec90686)

--- a/dist/angular-post-message.js
+++ b/dist/angular-post-message.js
@@ -1,6 +1,6 @@
 /*!
 * angular-post-message v1.3.1
-* Copyright 2015 Kyle Welsby <kyle@mekyle.com>
+* Copyright 2016 Kyle Welsby <kyle@mekyle.com>
 * Licensed under The MIT License
 */
 (function() {
@@ -10,8 +10,8 @@
   app = angular.module("ngPostMessage", ['ng']);
 
   app.run([
-    '$window', '$postMessage', '$rootScope', '$log',
-    function($window, $postMessage, $rootScope, $log) {
+    '$window', '$postMessage', '$rootScope',
+    function($window, $postMessage, $rootScope) {
 
       $rootScope.$on('$messageOutgoing', function(event, message, domain) {
         var sender;
@@ -31,9 +31,8 @@
           try {
             response = angular.fromJson(event.data);
           } catch (_error) {
-            error = _error;
-            $log.error('ahem', error);
-            response = event.data;
+            response = {};
+            response.text = event.data;
           }
           response.origin = event.origin;
           $rootScope.$root.$broadcast('$messageIncoming', response);

--- a/dist/angular-post-message.min.js
+++ b/dist/angular-post-message.min.js
@@ -1,6 +1,6 @@
 /*!
 * angular-post-message v1.3.1
-* Copyright 2015 Kyle Welsby <kyle@mekyle.com>
+* Copyright 2016 Kyle Welsby <kyle@mekyle.com>
 * Licensed under The MIT License
 */
-(function(){"use strict";var a;a=angular.module("ngPostMessage",["ng"]),a.run(["$window","$postMessage","$rootScope","$log",function(a,b,c,d){c.$on("$messageOutgoing",function(b,d,e){var f;return null==e&&(e="*"),f=c.sender||a.parent,f.postMessage(d,e)}),angular.element(a).bind("message",function(a){var e,f;if(a=a.originalEvent||a,a&&a.data){f=null,c.sender=a.source;try{f=angular.fromJson(a.data)}catch(g){e=g,d.error("ahem",e),f=a.data}return f.origin=a.origin,c.$root.$broadcast("$messageIncoming",f),b.messages(f)}})}]),a.factory("$postMessage",["$rootScope",function(a){var b,c;return b=[],c={messages:function(c){return c&&(b.push(c),a.$digest()),b},lastMessage:function(){return b[b.length-1]},post:function(b,c){return c||(c="*"),a.$broadcast("$messageOutgoing",b,c)}}}])}).call(this);
+(function(){"use strict";var a;a=angular.module("ngPostMessage",["ng"]),a.run(["$window","$postMessage","$rootScope",function(a,b,c){c.$on("$messageOutgoing",function(b,d,e){var f;return null==e&&(e="*"),f=c.sender||a.parent,f.postMessage(d,e)}),angular.element(a).bind("message",function(a){var d;if(a=a.originalEvent||a,a&&a.data){d=null,c.sender=a.source;try{d=angular.fromJson(a.data)}catch(e){d={},d.text=a.data}return d.origin=a.origin,c.$root.$broadcast("$messageIncoming",d),b.messages(d)}})}]),a.factory("$postMessage",["$rootScope",function(a){var b,c;return b=[],c={messages:function(c){return c&&(b.push(c),a.$digest()),b},lastMessage:function(){return b[b.length-1]},post:function(b,c){return c||(c="*"),a.$broadcast("$messageOutgoing",b,c)}}}])}).call(this);

--- a/src/angular-post-message.js
+++ b/src/angular-post-message.js
@@ -5,8 +5,8 @@
   app = angular.module("ngPostMessage", ['ng']);
 
   app.run([
-    '$window', '$postMessage', '$rootScope', '$log',
-    function($window, $postMessage, $rootScope, $log) {
+    '$window', '$postMessage', '$rootScope',
+    function($window, $postMessage, $rootScope) {
 
       $rootScope.$on('$messageOutgoing', function(event, message, domain) {
         var sender;
@@ -26,9 +26,8 @@
           try {
             response = angular.fromJson(event.data);
           } catch (_error) {
-            error = _error;
-            $log.error('ahem', error);
-            response = event.data;
+            response = {};
+            response.text = event.data;
           }
           response.origin = event.origin;
           $rootScope.$root.$broadcast('$messageIncoming', response);

--- a/tests/angular-post-message.js
+++ b/tests/angular-post-message.js
@@ -9,7 +9,7 @@
     beforeEach(inject(function(_$rootScope_, _$postMessage_) {
       $rootScope = _$rootScope_;
       postMessage = _$postMessage_;
-      messages = ["foo", "bar"];
+      messages = ["foo", "bar", '{ "foo": "bar" }', { foo: "bar" }];
     }));
     it("has no messages", function() {
       expect(postMessage.messages[0]).toBeUndefined();
@@ -40,6 +40,22 @@
       $rootScope.$on("$messageOutgoing", outgoingMessageListener);
       postMessage.post(messages[0]);
       expect(outgoingMessageListener.calls.first().args[1]).toEqual(messages[0]);
+    });
+
+    it("should add data to object for valid JSON data", function(done) {
+      $rootScope.$on("$messageIncoming", function(e, message) {
+        expect(message.foo).toEqual(messages[3].foo);
+        done();
+      });
+      window.postMessage(messages[2], "*");
+    });
+
+    it("should set origin for valid JSON data", function(done) {
+      $rootScope.$on("$messageIncoming", function(e, message) {
+        expect(message.origin).not.toBeUndefined();
+        done();
+      });
+      window.postMessage(messages[2], "*");
     });
   });
 

--- a/tests/angular-post-message.js
+++ b/tests/angular-post-message.js
@@ -43,20 +43,41 @@
     });
 
     it("should add data to object for valid JSON data", function(done) {
-      $rootScope.$on("$messageIncoming", function(e, message) {
+      var off = $rootScope.$on("$messageIncoming", function(e, message) {
         expect(message.foo).toEqual(messages[3].foo);
+        off();
         done();
       });
       window.postMessage(messages[2], "*");
     });
 
     it("should set origin for valid JSON data", function(done) {
-      $rootScope.$on("$messageIncoming", function(e, message) {
+      var off = $rootScope.$on("$messageIncoming", function(e, message) {
         expect(message.origin).not.toBeUndefined();
+        off();
         done();
       });
       window.postMessage(messages[2], "*");
     });
+
+    it("should return valid object for non JSON formatted message", function(done) {
+      var off = $rootScope.$on("$messageIncoming", function(e, message) {
+        expect(message.text).toEqual(messages[0]);
+        off();
+        done();
+      });
+      window.postMessage(messages[0], "*");
+    });
+
+    it("should set origin for non JSON formatted message", function(done) {
+      var off = $rootScope.$on("$messageIncoming", function(e, message) {
+        expect(message.origin).not.toBeUndefined();
+        off();
+        done();
+      });
+      window.postMessage(messages[0], "*");
+    });
+
   });
 
 }).call(this);


### PR DESCRIPTION
Finally found some time to get this submitted. Let me know your thoughts and anything you might like to change. I updated the version number and changelog. Wasn't sure if that was overstepping my bounds. Can certainly remove those if needed. Thanks again.
- Add test for JSON properties set on returned object
- Add test for origin set on returned object
- Handle non JSON formatted messages and attach message to `text`
  property or response object if message cannot be parsed as JSON
- Add tests for JSON formatted and non JSON formatted messages
- Remove `$log.error` that was called on each non JSON message
- Fix exception when non JSON formatted message was passed in
- Update changelog
- Move to verion 1.4.0 as response format has changed

Closes #12 
